### PR TITLE
add footer to email for sending bills in return

### DIFF
--- a/app/mailers/bill_mailer.rb
+++ b/app/mailers/bill_mailer.rb
@@ -13,6 +13,15 @@ class BillMailer < ApplicationMailer
       attachments.inline[file_name] = buck.to_blob
     end
     @from_email = from_email
+
+    @return_wad_params = {
+      to: buck_wad.from,
+      from: buck_wad.to,
+      count: buck_wad.count,
+      to_email: from_email,
+      dept: buck_wad.dept
+    }
+
     mail(
       to: to_email,
       reply_to: from_email,

--- a/app/models/buck_wad.rb
+++ b/app/models/buck_wad.rb
@@ -8,6 +8,12 @@ class BuckWad
   attr_reader :from
   sig { returns(String) }
   attr_reader :for_message
+  sig { returns(String) }
+  attr_reader :to
+  sig { returns(Integer) }
+  attr_reader :count
+  sig { returns(T.nilable(String)) }
+  attr_reader :dept
 
   sig do
     params(
@@ -20,9 +26,12 @@ class BuckWad
   end
   def initialize(to: '', from: '', for_message: '', count: 1, dept: '')
     @from = T.let(from.to_s, String)
+    @to = T.let(to.to_s, String)
     @for_message = T.let(for_message.to_s, String)
+    @dept = dept
     image_params = { to: to, from: from, for_message: for_message, dept: dept }
     count = count.to_i
+    @count = T.let(count, Integer)
     number_of_vonetts = count / 5
     number_of_bills = count % 5
 

--- a/app/views/bill_mailer/bill.html.erb
+++ b/app/views/bill_mailer/bill.html.erb
@@ -18,3 +18,11 @@
 <% @buck_wad.bucks_by_filename.keys.each do |filename| %>
 <%= image_tag(attachments[filename].url, size: "300x288") %>
 <% end %>
+
+<hr>
+
+<p>
+  What's this?
+  See <a href="https://help.cru.org/bills">help.cru.org/bills</a> for details,
+  or <%= link_to("send some Bill Bucks back", bucks_new_url(@return_wad_params)) %>!
+</p>


### PR DESCRIPTION
Closes #30 

See footer on this screenshot:
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/1080613/131889564-e2589b1b-6c46-4cc7-9361-a9def088f7f5.png">
